### PR TITLE
api,webhook: add a generic API handler and use it to handle webhooks

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -22,7 +22,7 @@ server {
     ...
 
     location /webhook {
-        proxy_pass http://unix:[ABSOLUTE PATH TO YOUR FORREST ENV]/webhook.sock:/webhook;
+        proxy_pass http://unix:[ABSOLUTE PATH TO YOUR FORREST ENV]/api.sock:/webhook;
         proxy_http_version 1.1;
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,72 @@
+use std::fs::Permissions;
+use std::os::unix::fs::PermissionsExt;
+
+use hyper::body::Incoming;
+use hyper::server::conn::http1::Builder as HttpConnectionBuilder;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use log::trace;
+use tokio::net::UnixListener;
+
+use crate::config::Config;
+
+pub struct Api {
+    listener: UnixListener,
+}
+
+impl Api {
+    pub fn new(config: Config) -> std::io::Result<Self> {
+        let listener = {
+            let cfg = config.get();
+
+            let path = cfg.host.base_dir.join("api.sock");
+
+            let _ = std::fs::remove_file(&path);
+
+            let listener = UnixListener::bind(&path)?;
+
+            // Allow anyone on the system to connect to the socket.
+            std::fs::set_permissions(path, Permissions::from_mode(0o777))?;
+
+            listener
+        };
+
+        Ok(Self { listener })
+    }
+
+    pub async fn run(self) -> std::io::Result<()> {
+        loop {
+            let (sock, _) = self.listener.accept().await?;
+
+            // Wrap the tokio socket in something that hyper understands.
+            let sock = TokioIo::new(sock);
+
+            tokio::task::spawn(async move {
+                // Wrap our handler function in something that hyper understands.
+                let service = service_fn(api_handler);
+
+                HttpConnectionBuilder::new()
+                    .serve_connection(sock, service)
+                    .await
+            });
+        }
+    }
+}
+
+async fn api_handler(request: Request<Incoming>) -> anyhow::Result<Response<String>> {
+    let first_path_component = request
+        .uri()
+        .path()
+        .trim_start_matches('/')
+        .split('/')
+        .next()
+        .unwrap_or("");
+
+    trace!("API request for: {}", first_path_component);
+
+    Ok(Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body("File not found".into())
+        .unwrap())
+}

--- a/src/ingres/webhook.rs
+++ b/src/ingres/webhook.rs
@@ -82,197 +82,199 @@ async fn webhook_handler(
     auth: &Auth,
     job_manager: &JobManager,
 ) -> anyhow::Result<Response<String>> {
-    let (parts, body) = request.into_parts();
+    {
+        let (parts, body) = request.into_parts();
 
-    if parts.uri.path() != "/webhook" {
-        return Ok(Response::builder()
-            .status(StatusCode::NOT_FOUND)
-            .body("Not found".into())
-            .unwrap());
-    }
-
-    if parts.method != Method::POST {
-        return Ok(Response::builder()
-            .status(StatusCode::METHOD_NOT_ALLOWED)
-            .body("Only HTTP POST is allowed".into())
-            .unwrap());
-    }
-
-    let event_type = match parts.headers.get("X-GitHub-Event") {
-        Some(et) => et,
-        None => {
+        if parts.uri.path() != "/webhook" {
             return Ok(Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body("Request is missing an X-GitHub-Event Header".into())
-                .unwrap());
-        }
-    };
-
-    let event_type = match event_type.to_str() {
-        Ok(et) => et,
-        Err(_) => {
-            return Ok(Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body("Failed to decode X-GitHub-Event Header".into())
-                .unwrap());
-        }
-    };
-
-    let signature = match parts.headers.get("X-Hub-Signature-256") {
-        Some(sig) => sig,
-        None => {
-            return Ok(Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body("Request is missing an X-Hub-Signature-256 Header".into())
-                .unwrap());
-        }
-    };
-
-    let signature = signature
-        .to_str()
-        .ok()
-        .and_then(|sig| sig.strip_prefix("sha256="))
-        .and_then(|sig| hex::decode(sig).ok());
-
-    let signature = match signature {
-        Some(sig) => sig,
-        None => {
-            return Ok(Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body("Failed to decode X-Hub-Signature-256 Header".into())
-                .unwrap());
-        }
-    };
-
-    let secret = config.github.webhook_secret.as_bytes();
-
-    let content = {
-        let content = body.collect().await?.to_bytes();
-
-        let hmac = {
-            let mut hmac: Hmac<Sha256> = Hmac::new_from_slice(secret).unwrap();
-            hmac.update(&content);
-            hmac
-        };
-
-        let content_valid = hmac.verify_slice(&signature);
-
-        if content_valid.is_err() {
-            return Ok(Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body("Signature validation failed".into())
+                .status(StatusCode::NOT_FOUND)
+                .body("Not found".into())
                 .unwrap());
         }
 
-        content
-    };
-
-    trace!("Got webhook event of type {event_type}");
-
-    let event = match WebhookEvent::try_from_header_and_body(event_type, &content) {
-        Ok(ev) => ev,
-        Err(_) => {
+        if parts.method != Method::POST {
             return Ok(Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body("Failed to parse request body".into())
+                .status(StatusCode::METHOD_NOT_ALLOWED)
+                .body("Only HTTP POST is allowed".into())
                 .unwrap());
         }
-    };
 
-    let job = match event.specific {
-        WebhookEventPayload::WorkflowJob(job) => job,
-        _ => {
-            return Ok(Response::builder()
-                .status(StatusCode::NO_CONTENT)
-                .body("".into())
-                .unwrap())
-        }
-    };
-
-    let oar = {
-        let repository = match event.repository {
-            Some(repo) => repo,
+        let event_type = match parts.headers.get("X-GitHub-Event") {
+            Some(et) => et,
             None => {
-                error!("Got workflow_job webhook event without repository field");
                 return Ok(Response::builder()
                     .status(StatusCode::BAD_REQUEST)
-                    .body("Workflow job is missing a repository field".into())
+                    .body("Request is missing an X-GitHub-Event Header".into())
                     .unwrap());
             }
         };
 
-        let owner = match repository.owner {
-            Some(owner) => owner.login,
-            None => {
-                error!("Got workflow_job webhook event without user in repository field");
+        let event_type = match event_type.to_str() {
+            Ok(et) => et,
+            Err(_) => {
                 return Ok(Response::builder()
                     .status(StatusCode::BAD_REQUEST)
-                    .body("Workflow job repository is missing an owner field".into())
+                    .body("Failed to decode X-GitHub-Event Header".into())
                     .unwrap());
             }
         };
 
-        OwnerAndRepo::new(owner, repository.name)
-    };
+        let signature = match parts.headers.get("X-Hub-Signature-256") {
+            Some(sig) => sig,
+            None => {
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body("Request is missing an X-Hub-Signature-256 Header".into())
+                    .unwrap());
+            }
+        };
 
-    let exists = config
-        .repositories
-        .get(oar.owner())
-        .and_then(|repos| repos.get(oar.repository()))
-        .is_some();
+        let signature = signature
+            .to_str()
+            .ok()
+            .and_then(|sig| sig.strip_prefix("sha256="))
+            .and_then(|sig| hex::decode(sig).ok());
 
-    if !exists {
-        info!("Refusing to service webhook from unlisted user/repo {oar}");
-        return Ok(Response::builder()
-            .status(StatusCode::UNAUTHORIZED)
-            .body("Unauthorized user/repo combination".into())
-            .unwrap());
-    }
+        let signature = match signature {
+            Some(sig) => sig,
+            None => {
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body("Failed to decode X-Hub-Signature-256 Header".into())
+                    .unwrap());
+            }
+        };
 
-    let installation_id = match event.installation {
-        Some(EventInstallation::Full(inst)) => inst.id,
-        Some(EventInstallation::Minimal(inst)) => inst.id,
-        None => {
-            error!("Got webhook event that was not sent by an installation");
+        let secret = config.github.webhook_secret.as_bytes();
+
+        let content = {
+            let content = body.collect().await?.to_bytes();
+
+            let hmac = {
+                let mut hmac: Hmac<Sha256> = Hmac::new_from_slice(secret).unwrap();
+                hmac.update(&content);
+                hmac
+            };
+
+            let content_valid = hmac.verify_slice(&signature);
+
+            if content_valid.is_err() {
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body("Signature validation failed".into())
+                    .unwrap());
+            }
+
+            content
+        };
+
+        trace!("Got webhook event of type {event_type}");
+
+        let event = match WebhookEvent::try_from_header_and_body(event_type, &content) {
+            Ok(ev) => ev,
+            Err(_) => {
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body("Failed to parse request body".into())
+                    .unwrap());
+            }
+        };
+
+        let job = match event.specific {
+            WebhookEventPayload::WorkflowJob(job) => job,
+            _ => {
+                return Ok(Response::builder()
+                    .status(StatusCode::NO_CONTENT)
+                    .body("".into())
+                    .unwrap())
+            }
+        };
+
+        let oar = {
+            let repository = match event.repository {
+                Some(repo) => repo,
+                None => {
+                    error!("Got workflow_job webhook event without repository field");
+                    return Ok(Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body("Workflow job is missing a repository field".into())
+                        .unwrap());
+                }
+            };
+
+            let owner = match repository.owner {
+                Some(owner) => owner.login,
+                None => {
+                    error!("Got workflow_job webhook event without user in repository field");
+                    return Ok(Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body("Workflow job repository is missing an owner field".into())
+                        .unwrap());
+                }
+            };
+
+            OwnerAndRepo::new(owner, repository.name)
+        };
+
+        let exists = config
+            .repositories
+            .get(oar.owner())
+            .and_then(|repos| repos.get(oar.repository()))
+            .is_some();
+
+        if !exists {
+            info!("Refusing to service webhook from unlisted user/repo {oar}");
             return Ok(Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body("The webhook event is missing an installation id".into())
+                .status(StatusCode::UNAUTHORIZED)
+                .body("Unauthorized user/repo combination".into())
                 .unwrap());
         }
-    };
 
-    let workflow_job: Job = match serde_json::from_value(job.workflow_job) {
-        Ok(workflow_job) => workflow_job,
-        Err(err) => {
-            error!("Could not parse workflow job received from webhook: {err}");
-            return Ok(Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body("Failed to parse workflow job".into())
-                .unwrap());
-        }
-    };
+        let installation_id = match event.installation {
+            Some(EventInstallation::Full(inst)) => inst.id,
+            Some(EventInstallation::Minimal(inst)) => inst.id,
+            None => {
+                error!("Got webhook event that was not sent by an installation");
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body("The webhook event is missing an installation id".into())
+                    .unwrap());
+            }
+        };
 
-    info!(
-        "Got webhook event for {oar} with labels: {}",
-        workflow_job.labels.join(",")
-    );
+        let workflow_job: Job = match serde_json::from_value(job.workflow_job) {
+            Ok(workflow_job) => workflow_job,
+            Err(err) => {
+                error!("Could not parse workflow job received from webhook: {err}");
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body("Failed to parse workflow job".into())
+                    .unwrap());
+            }
+        };
 
-    // Associate the user with their installation id so we can make API
-    // requests on their behalf later.
-    auth.update_user(oar.owner(), installation_id);
-
-    if let Some(triplet) = oar.into_triplet_via_labels(&workflow_job.labels) {
-        job_manager.status_feedback(
-            &triplet,
-            workflow_job.id,
-            workflow_job.run_id,
-            workflow_job.status,
-            workflow_job.runner_name.as_deref(),
+        info!(
+            "Got webhook event for {oar} with labels: {}",
+            workflow_job.labels.join(",")
         );
-    }
 
-    Ok(Response::builder()
-        .status(StatusCode::NO_CONTENT)
-        .body("".into())
-        .unwrap())
+        // Associate the user with their installation id so we can make API
+        // requests on their behalf later.
+        auth.update_user(oar.owner(), installation_id);
+
+        if let Some(triplet) = oar.into_triplet_via_labels(&workflow_job.labels) {
+            job_manager.status_feedback(
+                &triplet,
+                workflow_job.id,
+                workflow_job.run_id,
+                workflow_job.status,
+                workflow_job.runner_name.as_deref(),
+            );
+        }
+
+        Ok(Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body("".into())
+            .unwrap())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,11 +40,11 @@ async fn forrest() -> anyhow::Result<()> {
 
     // The main method to learn about new jobs to run is via webhooks.
     // These are POST requests sent by GitHub notifying us about events.
-    let mut webhook =
-        ingres::WebhookHandler::new(config.clone(), auth.clone(), job_manager.clone())?;
+    let webhook = ingres::WebhookHandler::new(config.clone(), auth.clone(), job_manager.clone());
 
-    // Provide a single unix domain socket for all API requests.
-    let api = api::Api::new(config.clone())?;
+    // Provide a single unix domain socket for all API requests like webhook
+    // requests from GitHub.
+    let api = api::Api::new(config.clone(), webhook)?;
 
     // Our secondary source of information are periodic polls of the GitHub API.
     // These come in handy at startup or after network outages when we may have
@@ -61,7 +61,6 @@ async fn forrest() -> anyhow::Result<()> {
 
     tokio::select! {
         res = machine_manager.janitor() => res,
-        res = webhook.run() => res,
         res = api.run() => res,
         res = poller.poll() => res,
     }?;


### PR DESCRIPTION
We want to provide a HTTP server from Forrest for various purposes, for now these are at least:

  - Webhooks from GitHub to notify about new jobs
  - Upload of Build artifacts

But in the future these may also be:

  - Web interface for the user
  - Metrics interface
  - Request persisting disk images via HTTP instead of FAT partition
  - GitLab support

Provide all of these via a single unix domain socket and leave the decision of whom to provide with what to the reverse proxy (e.g nginx).

---

TODO before merging:

- [x] This PR is based on #19, merge that one first.
- [x] This PR is based on #20, merge that one first.