### PR TITLE
machines: enable the use of a more compact labels format

### DIFF
--- a/src/config/machine.rs
+++ b/src/config/machine.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::Deserialize;
 
 use super::size_in_bytes::SizeInBytes;
-use crate::machines::Triplet;
+use crate::machines::OwnerRepoMachine;
 
 #[derive(Deserialize)]
 pub struct SetupTemplate {
@@ -40,7 +40,7 @@ impl Default for SeedBasePolicy {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MachineConfig {
-    pub base_machine: Option<Triplet>,
+    pub base_machine: Option<OwnerRepoMachine>,
     pub base_image: Option<PathBuf>,
     pub setup_template: SetupTemplate,
 

--- a/src/ingres/poll.rs
+++ b/src/ingres/poll.rs
@@ -98,10 +98,7 @@ impl Poller {
             }
 
             for job in jobs.items {
-                let triplet = match oar.clone().into_triplet_via_labels(&job.labels) {
-                    Some(triplet) => triplet,
-                    None => continue,
-                };
+                let triplet = oar.clone().into_triplet(job.labels);
 
                 // Update the job state in the job manager or create the job there
                 // in the first place.

--- a/src/ingres/webhook.rs
+++ b/src/ingres/webhook.rs
@@ -292,10 +292,7 @@ async fn workflow_job_handler(
     // requests on their behalf later.
     auth.update_user(oar.owner(), installation_id);
 
-    let triplet = match oar.into_triplet_via_labels(&workflow_job.labels) {
-        Some(triplet) => triplet,
-        None => return,
-    };
+    let triplet = oar.into_triplet(workflow_job.labels);
 
     job_manager.status_feedback(
         &triplet,

--- a/src/machines.rs
+++ b/src/machines.rs
@@ -5,4 +5,4 @@ mod run_dir;
 mod triplet;
 
 pub use manager::Manager;
-pub use triplet::{OwnerAndRepo, Triplet};
+pub use triplet::{OwnerAndRepo, OwnerRepoMachine, Triplet};

--- a/src/machines/machine.rs
+++ b/src/machines/machine.rs
@@ -157,11 +157,19 @@ impl Machine {
         rescheduler: Rescheduler,
         triplet: Triplet,
     ) -> Option<Arc<Self>> {
+        let machine_name = match triplet.machine_name() {
+            Ok(machine_name) => machine_name,
+            Err(e) => {
+                debug!("Got request with unsupported label combination: {e}");
+                return None;
+            }
+        };
+
         let machine_config = cfg
             .repositories
             .get(triplet.owner())
             .and_then(|repos| repos.get(triplet.repository()))
-            .and_then(|repo| repo.machines.get(triplet.machine_name()));
+            .and_then(|repo| repo.machines.get(machine_name));
 
         if machine_config.is_none() {
             error!("Got request for unknown machine triplet: {triplet}");
@@ -173,7 +181,7 @@ impl Machine {
 
             let mut name = b"forrest-".to_vec();
 
-            name.extend(triplet.machine_name().as_bytes());
+            name.extend(machine_name.as_bytes());
             name.push(b'-');
             name.extend(rng().sample_iter(&Alphanumeric).take(16));
 
@@ -230,12 +238,13 @@ impl Machine {
     pub(super) fn machine_config(&self) -> &MachineConfig {
         let cfg = self.cfg();
         let triplet = self.triplet();
+        let machine_name = triplet.machine_name().unwrap();
 
         let machine_config = cfg
             .repositories
             .get(triplet.owner())
             .and_then(|repos| repos.get(triplet.repository()))
-            .and_then(|repo| repo.machines.get(triplet.machine_name()));
+            .and_then(|repo| repo.machines.get(machine_name));
 
         machine_config.unwrap()
     }
@@ -286,12 +295,6 @@ impl Machine {
             let triplet = machine.triplet();
             let installation_octocrab = machine.auth.user(machine.triplet.owner()).unwrap();
 
-            let labels = vec![
-                "self-hosted".to_owned(),
-                "forrest".to_owned(),
-                triplet.machine_name().into(),
-            ];
-
             let runner_group = RunnerGroupId(1);
 
             let jit_config = installation_octocrab
@@ -301,7 +304,7 @@ impl Machine {
                     triplet.repository(),
                     &machine.runner_name,
                     runner_group,
-                    labels,
+                    triplet.labels(),
                 )
                 .send()
                 .await;
@@ -510,7 +513,17 @@ impl Machine {
                     }
                 };
 
-                let run_dir = RunDir::new(self, machines, encoded_jit_config);
+                let triplet = self.triplet();
+                let orm = triplet.clone().into_owner_repo_machine().unwrap();
+
+                let run_dir = RunDir::new(
+                    &orm,
+                    self.cfg(),
+                    self.machine_config(),
+                    self.runner_name(),
+                    machines,
+                    encoded_jit_config,
+                );
 
                 match run_dir {
                     Ok(run_dir) => inner.run_dir = run_dir,

--- a/src/machines/manager.rs
+++ b/src/machines/manager.rs
@@ -251,11 +251,7 @@ impl Manager {
 
                         let labels: Vec<_> =
                             runner.labels.into_iter().map(|label| label.name).collect();
-
-                        let triplet = match oar.clone().into_triplet_via_labels(&labels) {
-                            Some(triplet) => triplet,
-                            None => continue,
-                        };
+                        let triplet = oar.clone().into_triplet(labels);
 
                         // Is the runner online (the action runner software on the machine is
                         // connected to GitHubs servers) right now?
@@ -317,7 +313,15 @@ impl Manager {
                 if start_timeout_elapsed {
                     error!("Runner {runner_name} on {triplet} failed to come up in time");
 
-                    let machine_image_path = triplet.machine_image_path(base_dir_path);
+                    let orm = match triplet.clone().into_owner_repo_machine() {
+                        Ok(orm) => orm,
+                        Err(e) => {
+                            debug!("Ignoring machine {triplet} during sweep: {e}");
+                            continue;
+                        }
+                    };
+
+                    let machine_image_path = orm.machine_image_path(base_dir_path);
 
                     machine.kill();
 

--- a/src/machines/run_dir.rs
+++ b/src/machines/run_dir.rs
@@ -5,11 +5,11 @@ use std::path::{Path, PathBuf};
 use log::{debug, error, info, warn};
 use reflink_copy::reflink;
 
-use crate::config::SeedBasePolicy;
+use crate::config::{ConfigFile, MachineConfig, SeedBasePolicy};
 
 use super::config_fs::ConfigFs;
-use super::machine::Machine;
 use super::manager::Machines;
+use super::triplet::OwnerRepoMachine;
 
 const JOB_CONFIG_IMAGE_SIZE: u64 = 1_000_000;
 const JOB_CONFIG_IMAGE_LABEL: &str = "JOBDATA";
@@ -49,6 +49,16 @@ fn pick_newer<'p>(a: &'p Path, b: &'p Path) -> std::io::Result<&'p Path> {
     }
 }
 
+fn machines_contains_orm(machines: &Machines, orm: &OwnerRepoMachine) -> bool {
+    machines.keys().all(|machine| {
+        machine.owner() == orm.owner()
+            && machine.repository() == orm.repository()
+            && machine
+                .machine_name()
+                .is_ok_and(|m| m == orm.machine_name())
+    })
+}
+
 impl RunDir {
     /// Create a directory for a machine run and populate it to match our qemu arguments
     ///
@@ -63,28 +73,27 @@ impl RunDir {
     ///
     /// Returns Ok(None) if the image file we want is not present yet.
     pub(super) fn new(
-        machine: &Machine,
+        orm: &OwnerRepoMachine,
+        cfg: &ConfigFile,
+        machine_config: &MachineConfig,
+        runner_name: &str,
         machines: &Machines,
         encoded_jit_config: String,
     ) -> std::io::Result<Option<Self>> {
-        let triplet = machine.triplet();
-        let cfg = machine.cfg();
-        let machine_config = machine.machine_config();
-
         let base_dir = &cfg.host.base_dir;
 
-        let machine_image = triplet.machine_image_path(base_dir);
+        let machine_image = orm.machine_image_path(base_dir);
 
         let base_image = match &machine_config.base_machine {
-            Some(base_triplet) if machines.contains_key(base_triplet) => {
-                info!("Delaying the startup of {machine} because its base {base_triplet} is currently running");
+            Some(base_orm) if machines_contains_orm(machines, base_orm) => {
+                info!("Delaying the startup of {orm} because its base {base_orm} is currently running");
                 return Ok(None);
             }
-            Some(base_triplet) => base_triplet.machine_image_path(base_dir),
+            Some(base_orm) => base_orm.machine_image_path(base_dir),
             None => match &machine_config.base_image {
                 Some(base_image) => base_image.clone(),
                 None => {
-                    warn!("Neither `base_machine` nor `base_image` configured for {machine}.");
+                    warn!("Neither `base_machine` nor `base_image` configured for {orm}.");
                     warn!("Falling back to machine image");
                     machine_image.clone()
                 }
@@ -99,7 +108,7 @@ impl RunDir {
 
         if !image.try_exists()? {
             info!(
-                "Delaying the startup of {machine} because the image {} does not exist (yet)",
+                "Delaying the startup of {orm} because the image {} does not exist (yet)",
                 image.display()
             );
             return Ok(None);
@@ -107,11 +116,11 @@ impl RunDir {
 
         let persistence_token = cfg
             .repositories
-            .get(triplet.owner())
-            .and_then(|repos| repos.get(triplet.repository()))
+            .get(orm.owner())
+            .and_then(|repos| repos.get(orm.repository()))
             .and_then(|repo| repo.persistence_token.clone());
 
-        let run_dir = triplet.run_dir_path(&cfg.host.base_dir, machine.runner_name());
+        let run_dir = orm.run_dir_path(&cfg.host.base_dir, runner_name);
 
         create_dir_all(&run_dir)?;
 
@@ -133,9 +142,9 @@ impl RunDir {
 
         let substitutions = {
             let mut sub = vec![
-                ("REPO_OWNER", triplet.owner()),
-                ("REPO_NAME", triplet.repository()),
-                ("MACHINE_NAME", triplet.machine_name()),
+                ("REPO_OWNER", orm.owner()),
+                ("REPO_NAME", orm.repository()),
+                ("MACHINE_NAME", orm.machine_name()),
                 ("JITCONFIG", encoded_jit_config.as_str()),
             ];
 

--- a/src/machines/triplet.rs
+++ b/src/machines/triplet.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use log::debug;
+use anyhow::bail;
 use serde::de::{Deserialize, Deserializer, Error};
 
 #[derive(PartialEq, Eq, Clone, Hash)]
@@ -11,6 +11,12 @@ pub struct OwnerAndRepo {
 
 #[derive(PartialEq, Eq, Clone, Hash)]
 pub struct Triplet {
+    owner: String,
+    repository: String,
+    labels: Vec<String>,
+}
+
+pub struct OwnerRepoMachine {
     owner: String,
     repository: String,
     machine_name: String,
@@ -24,35 +30,12 @@ impl OwnerAndRepo {
         }
     }
 
-    pub fn into_triplet(self, machine_name: impl ToString) -> Triplet {
+    pub fn into_triplet(self, labels: Vec<String>) -> Triplet {
         Triplet {
             owner: self.owner,
             repository: self.repository,
-            machine_name: machine_name.to_string(),
+            labels,
         }
-    }
-
-    pub fn into_triplet_via_labels(self, labels: &[String]) -> Option<Triplet> {
-        if labels.len() != 3 {
-            debug!("Ignoring job with {} != 3 labels on {self}", labels.len());
-            return None;
-        }
-
-        let self_hosted = &labels[0];
-        let forrest = &labels[1];
-        let machine_name = &labels[2];
-
-        if self_hosted != "self-hosted" {
-            debug!("Ignoring job with '{self_hosted}' instead of 'self-hosted' as first label");
-            return None;
-        }
-
-        if forrest != "forrest" {
-            debug!("Ignoring job with '{forrest}' instead of 'forrest' as first label");
-            return None;
-        }
-
-        Some(self.into_triplet(machine_name))
     }
 
     pub fn owner(&self) -> &str {
@@ -71,18 +54,87 @@ impl std::fmt::Display for OwnerAndRepo {
 }
 
 impl Triplet {
-    pub fn new(
-        owner: impl ToString,
-        repository: impl ToString,
-        machine_name: impl ToString,
-    ) -> Self {
-        Self {
-            owner: owner.to_string(),
-            repository: repository.to_string(),
-            machine_name: machine_name.to_string(),
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    pub fn repository(&self) -> &str {
+        &self.repository
+    }
+
+    pub fn labels(&self) -> &[String] {
+        &self.labels
+    }
+
+    pub fn machine_name(&self) -> anyhow::Result<&str> {
+        match self.labels.as_slice() {
+            [single] => match single.strip_prefix("self-hosted/forrest/") {
+                Some(machine_name) => Ok(machine_name),
+                None => bail!("Single label does not match shorthand format"),
+            },
+            [self_hosted, forrest, machine_name] => {
+                if self_hosted != "self-hosted" {
+                    bail!("First of three labels is not \"self-hosted\"");
+                }
+
+                if forrest != "forrest" {
+                    bail!("Second of three labels is not \"forrest\"");
+                }
+
+                Ok(machine_name)
+            }
+            _ => {
+                bail!(
+                    "Job has unsupported number of labels: {}",
+                    self.labels.len()
+                );
+            }
         }
     }
 
+    pub fn into_owner_repo_machine(self) -> anyhow::Result<OwnerRepoMachine> {
+        let machine_name = self.machine_name()?.to_owned();
+
+        let orm = OwnerRepoMachine {
+            owner: self.owner,
+            repository: self.repository,
+            machine_name,
+        };
+
+        Ok(orm)
+    }
+
+    pub fn into_owner_and_repo(self) -> OwnerAndRepo {
+        OwnerAndRepo {
+            owner: self.owner,
+            repository: self.repository,
+        }
+    }
+}
+
+impl std::fmt::Display for Triplet {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{} {} [", self.owner, self.repository)?;
+
+        let nl = self.labels.len() - 2;
+
+        for label in &self.labels[..(nl - 2)] {
+            write!(f, "{}, ", label)?;
+        }
+
+        write!(f, "{}]", self.labels[nl - 1])?;
+
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for Triplet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
+impl OwnerRepoMachine {
     pub fn owner(&self) -> &str {
         &self.owner
     }
@@ -93,13 +145,6 @@ impl Triplet {
 
     pub fn machine_name(&self) -> &str {
         &self.machine_name
-    }
-
-    pub fn into_owner_and_repo(self) -> OwnerAndRepo {
-        OwnerAndRepo {
-            owner: self.owner,
-            repository: self.repository,
-        }
     }
 
     pub(super) fn run_dir_path(&self, base_dir_path: &Path, runner_name: &str) -> PathBuf {
@@ -120,30 +165,14 @@ impl Triplet {
     }
 }
 
-impl std::fmt::Display for Triplet {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "{}/{}/{}",
-            self.owner, self.repository, self.machine_name
-        )
-    }
-}
-
-impl std::fmt::Debug for Triplet {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self, f)
-    }
-}
-
-impl<'de> Deserialize<'de> for Triplet {
+impl<'de> Deserialize<'de> for OwnerRepoMachine {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let triplet_str: String = Deserialize::deserialize(deserializer)?;
+        let orm_str: String = Deserialize::deserialize(deserializer)?;
 
-        let parts: Vec<&str> = triplet_str.split('/').collect();
+        let parts: Vec<&str> = orm_str.split('/').collect();
         let parts_len = parts.len();
 
         if parts_len != 3 {
@@ -153,6 +182,22 @@ impl<'de> Deserialize<'de> for Triplet {
             ));
         }
 
-        Ok(Self::new(parts[0], parts[1], parts[2]))
+        let orm = OwnerRepoMachine {
+            owner: parts[0].to_owned(),
+            repository: parts[1].to_owned(),
+            machine_name: parts[2].to_owned(),
+        };
+
+        Ok(orm)
+    }
+}
+
+impl std::fmt::Display for OwnerRepoMachine {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}/{}/{}",
+            self.owner, self.repository, self.machine_name
+        )
     }
 }


### PR DESCRIPTION
This PR allows using:

```yaml
jobs:
  build:
    runs-on: self-hosted/forrest/build
```

Instead of:

```yaml
jobs:
  build:
    runs-on: ["self-hosted", "forrest", "build"]
```

Or, more importently:

```yaml
jobs:
  build:
    runs-on: ${{ github.repository == 'rauc/meta-rauc' && 'self-hosted/forrest/build' || 'ubuntu-22.04' }}
```

Instead of:

```yaml
jobs:
  build:
    runs-on: >-
      ${{
        (github.repository == 'rauc/meta-rauc' && fromJSON('["self-hosted", "forrest", "build"]')) ||
        'ubuntu-22.04'
      }}
```

---

This is a early draft, lacking polish, splitting into commits and commit messages.