### PR TITLE
api: inline variable in trace!() format string

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -76,7 +76,7 @@ async fn api_handler(
         .next()
         .unwrap_or("");
 
-    trace!("API request for: {}", first_path_component);
+    trace!("API request for: {first_path_component}");
 
     match first_path_component {
         "webhook" => handlers.webhook.handle(request).await,


### PR DESCRIPTION
This change was prompted by the new clippy lint [`uninlined_format_args`][1].

[1]: https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args