### PR TITLE
machines: machine,manager: fix clippy warning about confusing lifetimes

### DIFF
--- a/src/machines/machine.rs
+++ b/src/machines/machine.rs
@@ -224,7 +224,7 @@ impl Machine {
         }))
     }
 
-    fn inner(&self) -> std::sync::MutexGuard<Inner> {
+    fn inner(&self) -> std::sync::MutexGuard<'_, Inner> {
         self.inner.lock().unwrap()
     }
 
@@ -270,7 +270,7 @@ impl Machine {
         machine_config.unwrap()
     }
 
-    pub fn artifact(&self, name: &str, extra_token: &str) -> Option<Artifact> {
+    pub fn artifact(&self, name: &str, extra_token: &str) -> Option<Artifact<'_>> {
         let machine_config = self.machine_config();
 
         for (quota_index, config) in machine_config.artifacts.iter().enumerate() {

--- a/src/machines/manager.rs
+++ b/src/machines/manager.rs
@@ -58,7 +58,7 @@ impl Manager {
     /// The lock does however not include the job states,
     /// so machines may still enter the stopped state while this
     /// lock is held.
-    fn machines(&self) -> std::sync::MutexGuard<Machines> {
+    fn machines(&self) -> std::sync::MutexGuard<'_, Machines> {
         let mut machines = self.machines.lock().unwrap();
 
         // Use the opportunity to clean up the machines.


### PR DESCRIPTION
This feels like something where clippy suggested the exact opposite in the past, but I am not in the mood to argue.

Fixes warnings like these:

    error: hiding a lifetime that's elided elsewhere is confusing
    Error:    --> src/machines/machine.rs:227:14
        |
    227 |     fn inner(&self) -> std::sync::MutexGuard<Inner> {
        |              ^^^^^     ---------------------------- the same lifetime is hidden here
        |              |
        |              the lifetime is elided here
        |
        = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
        = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
        = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
    help: use `'_` for type paths
        |
    227 |     fn inner(&self) -> std::sync::MutexGuard<'_, Inner> {
        |                                              +++

This should fix the CI build error seen [in this scheduled run](https://github.com/forrest-runner/forrest/actions/runs/16815601991/job/47631521209).